### PR TITLE
Remove duplicate #[feature(plugin)]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,6 @@
 #![feature(slice_patterns)]
 #![feature(test)]
 #![feature(non_ascii_idents)]
-#![feature(plugin)]
 #![cfg_attr(test, plugin(stainless))]
 
 extern crate itertools;


### PR DESCRIPTION
Fixes compilation on newest nightly Rust due to rust-lang/rust#52644.