### PR TITLE
Behave more logically consistent with empty inputs

### DIFF
--- a/src/is_hiragana.rs
+++ b/src/is_hiragana.rs
@@ -11,9 +11,6 @@
 use crate::utils::is_char_hiragana::*;
 
 pub fn is_hiragana(input: &str) -> bool {
-    if input.is_empty() {
-        return false;
-    }
     input.chars().all(is_char_hiragana)
 }
 
@@ -22,4 +19,5 @@ fn check_is_hiragana() {
     assert_eq!(is_hiragana("げーむ"), true);
     assert_eq!(is_hiragana("A"), false);
     assert_eq!(is_hiragana("あア"), false);
+    assert_eq!(is_hiragana(""), true);
 }

--- a/src/is_japanese.rs
+++ b/src/is_japanese.rs
@@ -9,6 +9,7 @@
 //! assert_eq!(is_japanese("泣き虫。！〜＄"), true); // Zenkaku/JA punctuation
 //! assert_eq!(is_japanese("泣き虫.!~$"), false); // Latin punctuation fails
 //! assert_eq!(is_japanese("A"), false);
+//! assert_eq!(is_japanese(""), true);
 //! ```
 
 use crate::utils::is_char_japanese::*;
@@ -16,17 +17,11 @@ use crate::utils::is_char_japanese::*;
 use regex::Regex;
 
 pub fn is_japanese(input: &str) -> bool {
-    if input.is_empty() {
-        return false;
-    }
     input.chars().all(is_char_japanese)
 }
 
 #[cfg(feature = "enable_regex")]
 pub fn is_japanese_with_whitelist(input: &str, allowed: Option<&Regex>) -> bool {
-    if input.is_empty() {
-        return false;
-    }
     input.chars().all(|char| {
         let is_jap = is_char_japanese(char);
         if !is_jap {

--- a/src/is_kana.rs
+++ b/src/is_kana.rs
@@ -8,13 +8,11 @@
 //! assert_eq!(is_kana("あーア"), true);
 //! assert_eq!(is_kana("A"), false);
 //! assert_eq!(is_kana("あAア"), false);
+//! assert_eq!(is_kana(""), true);
 //! ```
 
 use crate::utils::is_char_kana::*;
 
 pub fn is_kana(input: &str) -> bool {
-    if input.is_empty() {
-        return false;
-    }
     input.chars().all(is_char_kana)
 }

--- a/src/is_kanji.rs
+++ b/src/is_kanji.rs
@@ -3,6 +3,7 @@
 //! # Examples
 //! ```
 //! use wana_kana::is_kanji::*;
+//! assert_eq!(is_kanji(""), true);
 //! assert_eq!(is_kanji("刀"), true);
 //! assert_eq!(is_kanji("切腹"), true);
 //! assert_eq!(is_kanji("勢い"), false);
@@ -10,20 +11,15 @@
 //! assert_eq!(is_kanji("あAア"), false);
 //! assert_eq!(is_kanji("🐸"), false);
 //! assert_eq!(contains_kanji("🐸"), false);
+//! assert_eq!(contains_kanji(""), false);
 //! ```
 
 use crate::utils::is_char_kanji::*;
 
 pub fn is_kanji(input: &str) -> bool {
-    if input.is_empty() {
-        return false;
-    }
     input.chars().all(is_char_kanji)
 }
 
 pub fn contains_kanji(input: &str) -> bool {
-    if input.is_empty() {
-        return false;
-    }
     input.chars().any(is_char_kanji)
 }

--- a/src/is_katakana.rs
+++ b/src/is_katakana.rs
@@ -7,13 +7,11 @@
 //! assert_eq!(is_katakana("あ"), false);
 //! assert_eq!(is_katakana("A"), false);
 //! assert_eq!(is_katakana("あア"), false);
+//! assert_eq!(is_katakana(""), true);
 //! ```
 
 use crate::utils::is_char_katakana::*;
 
 pub fn is_katakana(input: &str) -> bool {
-    if input.is_empty() {
-        return false;
-    }
     input.chars().all(is_char_katakana)
 }

--- a/src/is_romaji.rs
+++ b/src/is_romaji.rs
@@ -3,6 +3,7 @@
 //! # Examples
 //! ```
 //! use wana_kana::is_romaji::*;
+//! assert_eq!(is_romaji(""), true);
 //! assert_eq!(is_romaji("A"), true);
 //! assert_eq!(is_romaji("xYz"), true);
 //! assert_eq!(is_romaji("Tōkyō and Ōsaka"), true);
@@ -20,26 +21,14 @@ use crate::utils::is_char_romaji::*;
 use regex::Regex;
 
 pub fn is_romaji(input: &str) -> bool {
-    if input.is_empty() {
-        return false;
-    }
     input.chars().all(is_char_romaji)
 }
 
 #[cfg(feature = "enable_regex")]
-pub fn is_romaji_with_whitelist(input: &str, allowed: Option<&Regex>) -> bool {
-    if input.is_empty() {
-        return false;
-    }
-    input.chars().all(|char| {
-        let is_jap = is_char_romaji(char);
-        if !is_jap {
-            if let Some(allowed) = allowed {
-                return allowed.is_match(input);
-            }
-        }
-        is_jap
-    })
+pub fn is_romaji_with_whitelist(input: &str, allowed: &Regex) -> bool {
+    input
+        .chars()
+        .all(|char| is_char_romaji(char) || allowed.is_match(&String::from(char)))
 }
 
 #[test]

--- a/src/trim_okurigana.rs
+++ b/src/trim_okurigana.rs
@@ -38,7 +38,8 @@ pub fn is_invalid_matcher(input: &str, match_kanji: Option<&str>) -> bool {
 }
 
 pub fn trim_okurigana_with_opt<'a>(input: &'a str, from_start: bool, match_kanji: Option<&str>) -> &'a str {
-    if !is_japanese(input)
+    if input.is_empty()
+        || !is_japanese(input)
         || is_leading_without_initial_kana(input, from_start)
         || is_trailing_without_final_kana(input, from_start)
         || is_invalid_matcher(input, match_kanji)

--- a/tests/is_hiragana.rs
+++ b/tests/is_hiragana.rs
@@ -15,7 +15,7 @@ use wana_kana::is_hiragana::*;
 
 speculate! {
     it "sane defaults" {
-        assert_eq!(is_hiragana(""), false);
+        assert_eq!(is_hiragana(""), true);
     }
     it "あ is hiragana" { assert_eq!(is_hiragana("あ"), true); }
     it "ああ is hiragana" { assert_eq!(is_hiragana("ああ"), true); }

--- a/tests/is_japanese.rs
+++ b/tests/is_japanese.rs
@@ -17,7 +17,7 @@ use wana_kana::is_japanese::*;
 use regex::Regex;
 speculate! {
     it "sane defaults" {
-        assert_eq!(is_japanese(""), false);
+        assert_eq!(is_japanese(""), true);
     }
     it "泣き虫 is japanese" {
         assert_eq!(is_japanese("泣き虫"), true);

--- a/tests/is_kana.rs
+++ b/tests/is_kana.rs
@@ -15,7 +15,7 @@ use wana_kana::is_kana::*;
 
 speculate! {
     it "sane defaults" {
-        assert_eq!(is_kana(""), false);
+        assert_eq!(is_kana(""), true);
     }
     it "あ is kana" { assert_eq!(is_kana("あ"), true);}
     it "ア is kana" { assert_eq!(is_kana("ア"), true);}

--- a/tests/is_kanji.rs
+++ b/tests/is_kanji.rs
@@ -15,7 +15,7 @@ use wana_kana::is_kanji::*;
 
 speculate! {
     it "sane defaults" {
-        assert_eq!(is_kanji(""), false);
+        assert_eq!(is_kanji(""), true);
         assert_eq!(contains_kanji(""), false);
     }
 

--- a/tests/is_katakana.rs
+++ b/tests/is_katakana.rs
@@ -15,7 +15,7 @@ use wana_kana::is_katakana::*;
 
 speculate! {
     it "sane defaults" {
-        assert_eq!(is_katakana(""), false);
+        assert_eq!(is_katakana(""), true);
     }
     it "アア is katakana" { assert_eq!(is_katakana("アア"), true); }
     it "ア is katakana" { assert_eq!(is_katakana("ア"), true); }

--- a/tests/is_romaji.rs
+++ b/tests/is_romaji.rs
@@ -17,10 +17,7 @@ use wana_kana::is_romaji::*;
 
 speculate! {
     it "sane defaults" {
-        assert_eq!(is_romaji(""), false);
-
-        #[cfg(feature = "enable_regex")]
-        assert_eq!(is_romaji_with_whitelist("", None), false);
+        assert_eq!(is_romaji(""), true);
     }
     it "A is romaji" { assert_eq!(is_romaji("A"), true); }
     it "xYz is romaji" { assert_eq!(is_romaji("xYz"), true); }
@@ -34,5 +31,5 @@ speculate! {
     it "fails zenkaku latin" { assert_eq!(is_romaji("ｈｅｌｌｏ"), false); }
 
     #[cfg(feature = "enable_regex")]
-    it "accepts optional allowed chars" { assert_eq!(is_romaji_with_whitelist("a！b&cーd", Some(&Regex::new(r"[！ー]").unwrap())), true); }
+    it "accepts optional allowed chars" { assert_eq!(is_romaji_with_whitelist("a！b&cーd", &Regex::new(r"[！ー]").unwrap()), true); }
 }


### PR DESCRIPTION
The mathematical convention is that for any element property, empty sets
satisfy the property (because all elements satisfy the property).  This
is called "vacuous truth".

This is consistent with the behavior of `Iterator::all()` and
`Iterator::any()`.

For example, we will treat:

    is_hiragana("") -> true
    is_japanese("") -> true

Without this change, we would have the behavior that adding characters
to a string could unintuitively change a property from false -> true -> false:

    is_japanese("") -> false
    is_japanese("あ") -> true  // Add あ
    is_japanese("あA") -> false  // Add A

Links:
- https://en.wikipedia.org/wiki/Empty_set
- https://en.wikipedia.org/wiki/Vacuous_truth