### PR TITLE
Fixed issue #13

### DIFF
--- a/src/utils/katakana_to_hiragana.rs
+++ b/src/utils/katakana_to_hiragana.rs
@@ -58,6 +58,11 @@ pub(crate) fn katakana_to_hiragana_with_opt(input: &str, is_destination_romaji: 
         } else if let (Some(previous_kana), true) =
             (previous_kana, is_char_inner_long_dash(char, index))
         {
+            if previous_kana == 'っ' {
+                // Because "っ" is returned as an empty character, "っー" is replaced with "-"
+                hira.push('-');
+                continue;
+            }
             // Transform previous_kana back to romaji, and slice off the vowel
             let romaji = TO_ROMAJI_NODE_TREE
                 .find_transition_node(previous_kana)

--- a/tests/conversion_tables.rs
+++ b/tests/conversion_tables.rs
@@ -355,7 +355,7 @@ pub const ROMA_TO_HIRA_KATA: [[&str; 3]; 338] = [
 ];
 
 #[allow(dead_code)]
-pub const HIRA_KATA_TO_ROMA: [[&str; 3]; 192] = [
+pub const HIRA_KATA_TO_ROMA: [[&str; 3]; 194] = [
     // symbols that should all be the same after conversion
     ["ヶ", "ヶ", "ヶ"],
     ["ヵ", "ヵ", "ヵ"],
@@ -558,4 +558,6 @@ pub const HIRA_KATA_TO_ROMA: [[&str; 3]; 192] = [
     ["", "スーパーマン", "suupaaman"],
     ["", "バレーボール", "bareebooru"],
     ["", "ソール", "sooru"],
+    ["", "ウーッー", "uu-"],
+    ["", "アッー", "a-"],
 ];


### PR DESCRIPTION
Fixed issue #13.

When "ッー" was included in the input string, Panic occurred because the output of the "ッ" vowel was an empty string. Fixed to convert "-" to "-" in case of "ッ".

```bash
$ ./target/release/to_romaji ウーッー
uu-
```

```bash
$ cargo test -- --test-threads 1
# ...
test result: ok. 24 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 6.07s
```

I am not confident in Rust, so if I am writing in an odd way, please let me know the best way to write.